### PR TITLE
Implement a simple Unix system using bitmap displays

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,16 @@ Firefly particles (Run on repeat):
 summon minecraft:area_effect_cloud ~ ~1 ~ {BukkitValues:{"firefly_particles:amount": 3}}
 ```
 
+Unix system:
+```
+# Switch to Unix System scene
+execute unless entity @e[tag=bitmap_display] run summon minecraft:marker ~ ~1.25 ~ {Tags:["pre_bitmap_display"],Rotation:[90f,0f]}
+tag @e[tag=pre_bitmap_display] add bitmap_display
+execute if entity @e[tag=bitmap_display] run playsound minecraft:block.beacon.activate block @a ~ ~ ~ 1 1
+
+# Use player chat to input Unix commands
+say <your_unix_command>
+```
 
 ## Development
 1. Clone or download the repo.

--- a/src/main/java/com/heledron/text_display_experiments/bitmaps/scenes/UnixSystemScene.kt
+++ b/src/main/java/com/heledron/text_display_experiments/bitmaps/scenes/UnixSystemScene.kt
@@ -1,0 +1,59 @@
+package com.heledron.text_display_experiments.bitmaps.scenes
+
+import com.heledron.text_display_experiments.utilities.Grid
+import org.bukkit.Color
+import org.bukkit.entity.Player
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+
+class UnixSystemScene : Scene {
+    private val height = 64
+    private val bitmap = Grid((height * 2.0).toInt(), height) { Color.BLACK }
+    override fun getBitmap() = bitmap
+
+    private val commandOutput = mutableListOf<String>()
+
+    fun handlePlayerChatInput(player: Player, message: String) {
+        val command = message.trim()
+        if (command.isNotEmpty()) {
+            val output = executeUnixCommand(command)
+            commandOutput.addAll(output)
+            updateBitmapDisplay()
+        }
+    }
+
+    private fun executeUnixCommand(command: String): List<String> {
+        val output = mutableListOf<String>()
+        try {
+            val process = Runtime.getRuntime().exec(command)
+            val inputStream = process.inputStream
+            val errorStream = process.errorStream
+
+            val inputReader = inputStream.bufferedReader()
+            val errorReader = errorStream.bufferedReader()
+
+            output.addAll(inputReader.readLines())
+            output.addAll(errorReader.readLines())
+
+            process.waitFor()
+        } catch (e: Exception) {
+            output.add("Error executing command: ${e.message}")
+        }
+        return output
+    }
+
+    private fun updateBitmapDisplay() {
+        bitmap.setAll { Color.BLACK }
+        val maxLines = bitmap.height
+        val linesToDisplay = commandOutput.takeLast(maxLines)
+
+        for ((index, line) in linesToDisplay.withIndex()) {
+            val y = index
+            for ((x, char) in line.withIndex()) {
+                if (x < bitmap.width) {
+                    bitmap[x to y] = Color.WHITE
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/heledron/text_display_experiments/bitmaps/setupBitmapDisplay.kt
+++ b/src/main/java/com/heledron/text_display_experiments/bitmaps/setupBitmapDisplay.kt
@@ -4,6 +4,7 @@ import com.heledron.text_display_experiments.bitmaps.scenes.MandelbrotSetScene
 import com.heledron.text_display_experiments.bitmaps.scenes.RainbowTriangleScene
 import com.heledron.text_display_experiments.bitmaps.scenes.RotatingCubeScene
 import com.heledron.text_display_experiments.bitmaps.scenes.Scene
+import com.heledron.text_display_experiments.bitmaps.scenes.UnixSystemScene
 import com.heledron.text_display_experiments.textBackgroundTransform
 import com.heledron.text_display_experiments.utilities.*
 import com.heledron.text_display_experiments.utilities.rendering.RenderEntityGroup
@@ -65,6 +66,8 @@ fun setupBitmapDisplay() {
         bitmapScene = when (bitmapScene) {
             is RainbowTriangleScene -> RotatingCubeScene()
             is RotatingCubeScene -> MandelbrotSetScene()
+            is MandelbrotSetScene -> UnixSystemScene()
+            is UnixSystemScene -> RainbowTriangleScene()
             else -> RainbowTriangleScene()
         }
 
@@ -198,6 +201,12 @@ fun setupBitmapDisplay() {
                 }
             ))
         }
+    }
+
+    // Handle player chat input
+    onPlayerChat { player, message ->
+        val unixSystemScene = bitmapScene as? UnixSystemScene ?: return@onPlayerChat
+        unixSystemScene.handlePlayerChatInput(player, message)
     }
 }
 


### PR DESCRIPTION
Implement a simple Unix system using bitmap displays and player chat for input.

* **UnixSystemScene.kt**
  - Add `UnixSystemScene` class to handle Unix system emulation.
  - Implement player chat input handling to process Unix commands.
  - Update bitmap display based on Unix command output.

* **setupBitmapDisplay.kt**
  - Import `UnixSystemScene` class.
  - Add `UnixSystemScene` to the scene cycle in `changeScene` item.
  - Handle player chat input to update `UnixSystemScene`.

* **README.md**
  - Add instructions for using the Unix system and player chat input.

